### PR TITLE
Set key information to protected set (OSK-5)

### DIFF
--- a/src/OSK.Security.Cryptography/CryptographicKeyService.cs
+++ b/src/OSK.Security.Cryptography/CryptographicKeyService.cs
@@ -10,7 +10,7 @@ namespace OSK.Security.Cryptography
     {
         #region ICryptographicKeyService
 
-        public TKeyInformation KeyInformation { get; protected set; }
+        public TKeyInformation KeyInformation { get; internal protected set; }
 
         public abstract ValueTask<byte[]> DecryptAsync(byte[] data, CancellationToken cancellationToken = default);
         public abstract ValueTask<byte[]> EncryptAsync(byte[] data, CancellationToken cancellationToken = default);

--- a/src/OSK.Security.Cryptography/CryptographicKeyService.cs
+++ b/src/OSK.Security.Cryptography/CryptographicKeyService.cs
@@ -10,7 +10,7 @@ namespace OSK.Security.Cryptography
     {
         #region ICryptographicKeyService
 
-        public TKeyInformation KeyInformation { get; internal set; }
+        public TKeyInformation KeyInformation { get; protected set; }
 
         public abstract ValueTask<byte[]> DecryptAsync(byte[] data, CancellationToken cancellationToken = default);
         public abstract ValueTask<byte[]> EncryptAsync(byte[] data, CancellationToken cancellationToken = default);


### PR DESCRIPTION
Motivation
----
Unit tests can't access the key information for testing

Modifications
----
* Make the key information a protected set so that implementations may set the value for unit testing

Results
----
Unit testing can validate the key information

Fixes #5