### PR TITLE
Update extensions to add the key service provider (OSK-7)

### DIFF
--- a/src/OSK.Security.Cryptography/ServiceCollectionExtensions.cs
+++ b/src/OSK.Security.Cryptography/ServiceCollectionExtensions.cs
@@ -1,15 +1,24 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OSK.Security.Cryptography.Abstractions;
+using OSK.Security.Cryptography.Internal.Services;
 
 namespace OSK.Security.Cryptography
 {
     public static class ServiceCollectionExtensions
     {
+        public static IServiceCollection AddCryptography(this IServiceCollection services)
+        {
+            services.TryAddTransient<ICryptographicKeyServiceProvider, CryptographicKeyServiceProvider>();
+
+            return services;
+        }
+
         public static IServiceCollection AddSymmetricKeyService<TCryptographicKeyService, TKeyInformation>(this IServiceCollection services)
             where TCryptographicKeyService : SymmetricKeyService<TKeyInformation>
             where TKeyInformation : class, ISymmetricKeyInformation
         {
+            services.AddCryptography();
             services.TryAddTransient<SymmetricKeyService<TKeyInformation>, TCryptographicKeyService>();
 
             return services;
@@ -19,6 +28,7 @@ namespace OSK.Security.Cryptography
             where TCryptographicKeyService : AsymmetricKeyService<TKeyInformation>
             where TKeyInformation : class, IAsymmetricKeyInformation
         {
+            services.AddCryptography();
             services.TryAddTransient<AsymmetricKeyService<TKeyInformation>, TCryptographicKeyService>();
 
             return services;


### PR DESCRIPTION
Motivation
----
DI is not currently getting an instance for the ICryptographyKeyServiceProvider

Modifications
----
* Add extension for this DI

Result
----
Consumers will now be able to get a cryptography key service utilizing the new CryptographyKeyServiceProvider

Fixes #7