### PR TITLE
Add an extra interface for non-key specific key usage (OSK-9)

### DIFF
--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService.cs
@@ -1,14 +1,10 @@
-﻿using System;
+﻿using System.Threading.Tasks;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace OSK.Security.Cryptography.Abstractions
 {
-    public interface ICryptographicKeyService<TKeyInformation> : IDisposable
-        where TKeyInformation : ICryptographicKeyInformation
+    public interface ICryptographicKeyService
     {
-        TKeyInformation KeyInformation { get; }
-
         ValueTask<byte[]> EncryptAsync(byte[] data, CancellationToken cancellationToken = default);
 
         ValueTask<byte[]> DecryptAsync(byte[] data, CancellationToken cancellationToken = default);

--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService`1.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService`1.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace OSK.Security.Cryptography.Abstractions
+{
+    public interface ICryptographicKeyService<TKeyInformation> : ICryptographicKeyService, IDisposable
+        where TKeyInformation : ICryptographicKeyInformation
+    {
+        TKeyInformation KeyInformation { get; }
+    }
+}


### PR DESCRIPTION
Motivation
----
Adding an extra interface for non-type usage, if desired

Modifications
----
* Added new interface

Result
----
Extra interface is now available for non-typed key service usage

Fixes #9