### PR TITLE
Allow generic gets on CryptographicKeyServiceProvider (OSK-11)

### DIFF
--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService.cs
@@ -8,7 +8,5 @@ namespace OSK.Security.Cryptography.Abstractions
         ValueTask<byte[]> EncryptAsync(byte[] data, CancellationToken cancellationToken = default);
 
         ValueTask<byte[]> DecryptAsync(byte[] data, CancellationToken cancellationToken = default);
-
-        bool TrySetKeyInformation(ICryptographicKeyInformation keyInformation);
     }
 }

--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService.cs
@@ -8,5 +8,7 @@ namespace OSK.Security.Cryptography.Abstractions
         ValueTask<byte[]> EncryptAsync(byte[] data, CancellationToken cancellationToken = default);
 
         ValueTask<byte[]> DecryptAsync(byte[] data, CancellationToken cancellationToken = default);
+
+        bool TrySetKeyInformation(ICryptographicKeyInformation keyInformation);
     }
 }

--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyServiceProvider.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyServiceProvider.cs
@@ -7,5 +7,7 @@
 
         IAsymmetricKeyService<TKeyInformation> GetAsymmetricKeyService<TKeyInformation>(TKeyInformation keyInformation)
             where TKeyInformation : class, IAsymmetricKeyInformation;
+
+        ICryptographicKeyService GetKeyService(ICryptographicKeyInformation keyInformation);
     }
 }

--- a/src/OSK.Security.Cryptography.UnitTests/Helpers/AsymmetricKeyTestInformation.cs
+++ b/src/OSK.Security.Cryptography.UnitTests/Helpers/AsymmetricKeyTestInformation.cs
@@ -1,0 +1,17 @@
+﻿using OSK.Security.Cryptography.Models;
+
+namespace OSK.Security.Cryptography.UnitTests.Helpers
+{
+    public class AsymmetricKeyTestInformation : AsymmetricKeyInformation<PublicKeyInformation>
+    {
+        public override void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override PublicKeyInformation GetPublicKeyInformation()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/OSK.Security.Cryptography.UnitTests/Helpers/AsymmetricKeyTestService.cs
+++ b/src/OSK.Security.Cryptography.UnitTests/Helpers/AsymmetricKeyTestService.cs
@@ -1,0 +1,27 @@
+﻿using System.Security.Cryptography;
+
+namespace OSK.Security.Cryptography.UnitTests.Helpers
+{
+    public class AsymmetricKeyTestService : AsymmetricKeyService<AsymmetricKeyTestInformation>
+    {
+        public override ValueTask<byte[]> DecryptAsync(byte[] data, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override ValueTask<byte[]> EncryptAsync(byte[] data, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override ValueTask<byte[]> SignAsync(byte[] data, HashAlgorithmName hashAlgorithmName, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override ValueTask<bool> ValidateSignatureAsync(byte[] data, byte[] signedData, HashAlgorithmName hashAlgorithmName, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/OSK.Security.Cryptography.UnitTests/Helpers/PublicKeyInformation.cs
+++ b/src/OSK.Security.Cryptography.UnitTests/Helpers/PublicKeyInformation.cs
@@ -1,0 +1,8 @@
+﻿using OSK.Security.Cryptography.Abstractions;
+
+namespace OSK.Security.Cryptography.UnitTests.Helpers
+{
+    public class PublicKeyInformation: IPublicKeyInformation
+    {
+    }
+}

--- a/src/OSK.Security.Cryptography.UnitTests/Helpers/SymmetricKeyTestInformation.cs
+++ b/src/OSK.Security.Cryptography.UnitTests/Helpers/SymmetricKeyTestInformation.cs
@@ -1,0 +1,17 @@
+﻿using OSK.Security.Cryptography.Models;
+
+namespace OSK.Security.Cryptography.UnitTests.Helpers
+{
+    public class SymmetricKeyTestInformation : SymmetricKeyInformation<PublicKeyInformation>
+    {
+        public override void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override PublicKeyInformation GetPublicKeyInformation()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/OSK.Security.Cryptography.UnitTests/Helpers/SymmetricKeyTestService.cs
+++ b/src/OSK.Security.Cryptography.UnitTests/Helpers/SymmetricKeyTestService.cs
@@ -1,0 +1,15 @@
+﻿namespace OSK.Security.Cryptography.UnitTests.Helpers
+{
+    public class SymmetricKeyTestService : SymmetricKeyService<SymmetricKeyTestInformation>
+    {
+        public override ValueTask<byte[]> DecryptAsync(byte[] data, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override ValueTask<byte[]> EncryptAsync(byte[] data, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/OSK.Security.Cryptography.UnitTests/Helpers/UnregisteredKeyTestInformation.cs
+++ b/src/OSK.Security.Cryptography.UnitTests/Helpers/UnregisteredKeyTestInformation.cs
@@ -1,0 +1,12 @@
+﻿using OSK.Security.Cryptography.Abstractions;
+
+namespace OSK.Security.Cryptography.UnitTests.Helpers
+{
+    public class UnregisteredKeyTestInformation : IAsymmetricKeyInformation, ISymmetricKeyInformation
+    {
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/OSK.Security.Cryptography.UnitTests/Internal/Services/CryptographicKeyServiceProviderUnitTests.cs
+++ b/src/OSK.Security.Cryptography.UnitTests/Internal/Services/CryptographicKeyServiceProviderUnitTests.cs
@@ -1,0 +1,132 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using OSK.Security.Cryptography.Abstractions;
+using OSK.Security.Cryptography.UnitTests.Helpers;
+using Xunit;
+
+namespace OSK.Security.Cryptography.UnitTests.Internal.Services
+{
+    public class CryptographicKeyServiceProviderUnitTests
+    {
+        #region Variables
+
+        private readonly ICryptographicKeyServiceProvider _keyServiceProvider;
+
+        #endregion
+
+        #region Constructors
+
+        public CryptographicKeyServiceProviderUnitTests()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddAsymmetricKeyService<AsymmetricKeyTestService, AsymmetricKeyTestInformation>();
+            serviceCollection.AddSymmetricKeyService<SymmetricKeyTestService, SymmetricKeyTestInformation>();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            _keyServiceProvider = serviceProvider.GetRequiredService<ICryptographicKeyServiceProvider>();
+        }
+
+        #endregion
+
+        #region GetAsymmetricKeyService
+
+        [Fact]
+        public void GetAsymmetricKeyService_NullKeyInformation_ThrowsArgumentNullException()
+        {
+            // Arrange/Act/Assert
+            Assert.Throws<ArgumentNullException>(() => _keyServiceProvider.GetAsymmetricKeyService<AsymmetricKeyTestInformation>(null));
+        }
+
+        [Fact]
+        public void GetAsymmetricKeyService_UnregisteredKeyInformation_ThrowsArgumentNullException()
+        {
+            // Arrange/Act/Assert
+            Assert.Throws<InvalidOperationException>(() => _keyServiceProvider.GetAsymmetricKeyService(new UnregisteredKeyTestInformation()));
+        }
+
+        [Fact]
+        public void GetAsymmetricKeyService_ValidKeyInformation_ReturnsSuccessfully()
+        {
+            // Arrange
+            var testInformation = new AsymmetricKeyTestInformation();
+
+            // Act
+            var keyService = _keyServiceProvider.GetAsymmetricKeyService(testInformation);
+
+            // Assert
+            Assert.NotNull(keyService);
+            Assert.Equal(testInformation, keyService.KeyInformation);
+        }
+
+        #endregion
+
+        #region GetSymmetricKeyService
+
+        [Fact]
+        public void GetSymmetricKeyService_NullKeyInformation_ThrowsArgumentNullException()
+        {
+            // Arrange/Act/Assert
+            Assert.Throws<ArgumentNullException>(() => _keyServiceProvider.GetSymmetricKeyService<SymmetricKeyTestInformation>(null));
+        }
+
+        [Fact]
+        public void GetSymmetricKeyService_UnregisteredKeyInformation_ThrowsArgumentNullException()
+        {
+            // Arrange/Act/Assert
+            Assert.Throws<InvalidOperationException>(() => _keyServiceProvider.GetSymmetricKeyService(new UnregisteredKeyTestInformation()));
+        }
+
+        [Fact]
+        public void GetSsymmetricKeyService_ValidKeyInformation_ReturnsSuccessfully()
+        {
+            // Arrange
+            var testInformation = new SymmetricKeyTestInformation();
+
+            // Act
+            var keyService = _keyServiceProvider.GetSymmetricKeyService(testInformation);
+
+            // Assert
+            Assert.NotNull(keyService);
+            Assert.Equal(testInformation, keyService.KeyInformation);
+        }
+
+        #endregion
+
+        #region GetKeyService
+
+        [Fact]
+        public void GetKeyService_NullKeyInformation_ThrowsArgumentNullException()
+        {
+            // Arrange/Act/Assert
+            Assert.Throws<ArgumentNullException>(() => _keyServiceProvider.GetKeyService(null));
+        }
+
+        [Fact]
+        public void GetKeyService_UnregisteredKeyInformation_ThrowsInvalidOperationException()
+        {
+            // Arrange/Act/Assert
+            Assert.Throws<InvalidOperationException>(() => _keyServiceProvider.GetKeyService(new UnregisteredKeyTestInformation()));
+        }
+
+        [Fact]
+        public void GetKeyService_GenericKeyInformation_ReturnsService()
+        {
+            // Arrange
+            var testInformation = new AsymmetricKeyTestInformation();
+            var testInformation2 = new SymmetricKeyTestInformation();
+
+            // Act
+            var service1 = _keyServiceProvider.GetKeyService(testInformation);
+            var service2 = _keyServiceProvider.GetKeyService(testInformation2);
+
+            // Assert
+            Assert.NotNull(service1);
+            Assert.IsType<AsymmetricKeyTestService>(service1);
+
+
+            Assert.NotNull(service2);
+            Assert.IsType<SymmetricKeyTestService>(service2);
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.Security.Cryptography.UnitTests/OSK.Security.Cryptography.UnitTests.csproj
+++ b/src/OSK.Security.Cryptography.UnitTests/OSK.Security.Cryptography.UnitTests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\OSK.Security.Cryptography\OSK.Security.Cryptography.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/OSK.Security.Cryptography.UnitTests/OSK.Security.Cryptography.UnitTests.csproj
+++ b/src/OSK.Security.Cryptography.UnitTests/OSK.Security.Cryptography.UnitTests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
@@ -16,7 +16,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <ProjectReference Include="..\OSK.Security.Cryptography\OSK.Security.Cryptography.csproj" />
+		<ProjectReference Include="..\OSK.Security.Cryptography\OSK.Security.Cryptography.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/OSK.Security.Cryptography.sln
+++ b/src/OSK.Security.Cryptography.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.Security.Cryptography.A
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.Security.Cryptography", "OSK.Security.Cryptography\OSK.Security.Cryptography.csproj", "{31BB46BA-18FB-4860-8313-F7F4806C8F0A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OSK.Security.Cryptography.UnitTests", "OSK.Security.Cryptography.UnitTests\OSK.Security.Cryptography.UnitTests.csproj", "{591BA75C-186C-45B6-B1F1-8373E675F645}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{31BB46BA-18FB-4860-8313-F7F4806C8F0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{31BB46BA-18FB-4860-8313-F7F4806C8F0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{31BB46BA-18FB-4860-8313-F7F4806C8F0A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{591BA75C-186C-45B6-B1F1-8373E675F645}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{591BA75C-186C-45B6-B1F1-8373E675F645}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{591BA75C-186C-45B6-B1F1-8373E675F645}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{591BA75C-186C-45B6-B1F1-8373E675F645}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/OSK.Security.Cryptography/CryptographicKeyService.cs
+++ b/src/OSK.Security.Cryptography/CryptographicKeyService.cs
@@ -1,25 +1,18 @@
 ﻿using OSK.Security.Cryptography.Abstractions;
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace OSK.Security.Cryptography
 {
-    public abstract class CryptographicKeyService<TKeyInformation> : ICryptographicKeyService<TKeyInformation>
-        where TKeyInformation : class, ICryptographicKeyInformation
+    public abstract class CryptographicKeyService : ICryptographicKeyService
     {
         #region ICryptographicKeyService
 
-        public TKeyInformation KeyInformation { get; internal protected set; }
-
         public abstract ValueTask<byte[]> DecryptAsync(byte[] data, CancellationToken cancellationToken = default);
+
         public abstract ValueTask<byte[]> EncryptAsync(byte[] data, CancellationToken cancellationToken = default);
 
-        public virtual void Dispose()
-        {
-            KeyInformation?.Dispose();
-            KeyInformation = null;
-        }
+        public abstract bool TrySetKeyInformation(ICryptographicKeyInformation keyInformation);
 
         #endregion
     }

--- a/src/OSK.Security.Cryptography/CryptographicKeyService.cs
+++ b/src/OSK.Security.Cryptography/CryptographicKeyService.cs
@@ -12,7 +12,11 @@ namespace OSK.Security.Cryptography
 
         public abstract ValueTask<byte[]> EncryptAsync(byte[] data, CancellationToken cancellationToken = default);
 
-        public abstract bool TrySetKeyInformation(ICryptographicKeyInformation keyInformation);
+        #endregion
+
+        #region Helpers
+
+        protected internal abstract bool TrySetKeyInformation(ICryptographicKeyInformation keyInformation);
 
         #endregion
     }

--- a/src/OSK.Security.Cryptography/CryptographicKeyService`1.cs
+++ b/src/OSK.Security.Cryptography/CryptographicKeyService`1.cs
@@ -19,7 +19,7 @@ namespace OSK.Security.Cryptography
 
         #region Helpers
 
-        public override bool TrySetKeyInformation(ICryptographicKeyInformation keyInformation)
+        protected internal override bool TrySetKeyInformation(ICryptographicKeyInformation keyInformation)
         {
             if (keyInformation is TKeyInformation typedKeyInformation)
             {

--- a/src/OSK.Security.Cryptography/CryptographicKeyService`1.cs
+++ b/src/OSK.Security.Cryptography/CryptographicKeyService`1.cs
@@ -7,7 +7,7 @@ namespace OSK.Security.Cryptography
     {
         #region ICryptographicKeyService
 
-        public TKeyInformation KeyInformation { get; internal protected set; }
+        public TKeyInformation KeyInformation { get; protected internal set; }
 
         public virtual void Dispose()
         {

--- a/src/OSK.Security.Cryptography/CryptographicKeyService`1.cs
+++ b/src/OSK.Security.Cryptography/CryptographicKeyService`1.cs
@@ -1,0 +1,35 @@
+﻿using OSK.Security.Cryptography.Abstractions;
+
+namespace OSK.Security.Cryptography
+{
+    public abstract class CryptographicKeyService<TKeyInformation> : CryptographicKeyService, ICryptographicKeyService<TKeyInformation>
+        where TKeyInformation : class, ICryptographicKeyInformation
+    {
+        #region ICryptographicKeyService
+
+        public TKeyInformation KeyInformation { get; internal protected set; }
+
+        public virtual void Dispose()
+        {
+            KeyInformation?.Dispose();
+            KeyInformation = null;
+        }
+
+        #endregion
+
+        #region Helpers
+
+        public override bool TrySetKeyInformation(ICryptographicKeyInformation keyInformation)
+        {
+            if (keyInformation is TKeyInformation typedKeyInformation)
+            {
+                KeyInformation = typedKeyInformation;
+                return true;
+            }
+
+            return false;
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.Security.Cryptography/Internal/Services/CryptographicKeyServiceProvider.cs
+++ b/src/OSK.Security.Cryptography/Internal/Services/CryptographicKeyServiceProvider.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using OSK.Security.Cryptography.Abstractions;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace OSK.Security.Cryptography.Internal.Services
 {
@@ -26,6 +28,11 @@ namespace OSK.Security.Cryptography.Internal.Services
         public IAsymmetricKeyService<TKeyInformation> GetAsymmetricKeyService<TKeyInformation>(TKeyInformation keyInformation) 
             where TKeyInformation : class, IAsymmetricKeyInformation
         {
+            if (keyInformation == null)
+            {
+                throw new ArgumentNullException(nameof(keyInformation));
+            }
+
             var keyService = _serviceProvider.GetRequiredService<AsymmetricKeyService<TKeyInformation>>();
             keyService.KeyInformation = keyInformation;
 
@@ -35,10 +42,32 @@ namespace OSK.Security.Cryptography.Internal.Services
         public ISymmetricKeyService<TKeyInformation> GetSymmetricKeyService<TKeyInformation>(TKeyInformation keyInformation)
             where TKeyInformation : class, ISymmetricKeyInformation
         {
+            if (keyInformation == null)
+            {
+                throw new ArgumentNullException(nameof(keyInformation));
+            }
+
             var keyService = _serviceProvider.GetRequiredService<SymmetricKeyService<TKeyInformation>>();
             keyService.KeyInformation = keyInformation;
 
             return keyService;
+        }
+
+        public ICryptographicKeyService GetKeyService(ICryptographicKeyInformation keyInformation)
+        {
+            if (keyInformation == null)
+            {
+                throw new ArgumentNullException(nameof(keyInformation));
+            }
+
+            var keyServices = _serviceProvider.GetRequiredService<IEnumerable<ICryptographicKeyService>>();
+            var selectedKeyService = keyServices.FirstOrDefault(keyService => keyService.TrySetKeyInformation(keyInformation));
+            if (selectedKeyService == null)
+            {
+                throw new InvalidOperationException($"No registered cryptographic key service could handle key information of type {keyInformation.GetType()}. Are you missing a dependency injection?");
+            }
+
+            return selectedKeyService;
         }
 
         #endregion

--- a/src/OSK.Security.Cryptography/Internal/Services/CryptographicKeyServiceProvider.cs
+++ b/src/OSK.Security.Cryptography/Internal/Services/CryptographicKeyServiceProvider.cs
@@ -60,7 +60,7 @@ namespace OSK.Security.Cryptography.Internal.Services
                 throw new ArgumentNullException(nameof(keyInformation));
             }
 
-            var keyServices = _serviceProvider.GetRequiredService<IEnumerable<ICryptographicKeyService>>();
+            var keyServices = _serviceProvider.GetRequiredService<IEnumerable<CryptographicKeyService>>();
             var selectedKeyService = keyServices.FirstOrDefault(keyService => keyService.TrySetKeyInformation(keyInformation));
             if (selectedKeyService == null)
             {

--- a/src/OSK.Security.Cryptography/ServiceCollectionExtensions.cs
+++ b/src/OSK.Security.Cryptography/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ namespace OSK.Security.Cryptography
         {
             services.AddCryptography();
             services.TryAddTransient<SymmetricKeyService<TKeyInformation>, TCryptographicKeyService>();
+            services.AddTransient<ICryptographicKeyService, TCryptographicKeyService>();
 
             return services;
         }
@@ -30,6 +31,7 @@ namespace OSK.Security.Cryptography
         {
             services.AddCryptography();
             services.TryAddTransient<AsymmetricKeyService<TKeyInformation>, TCryptographicKeyService>();
+            services.AddTransient<ICryptographicKeyService, TCryptographicKeyService>();
 
             return services;
         }

--- a/src/OSK.Security.Cryptography/ServiceCollectionExtensions.cs
+++ b/src/OSK.Security.Cryptography/ServiceCollectionExtensions.cs
@@ -20,7 +20,7 @@ namespace OSK.Security.Cryptography
         {
             services.AddCryptography();
             services.TryAddTransient<SymmetricKeyService<TKeyInformation>, TCryptographicKeyService>();
-            services.AddTransient<ICryptographicKeyService, TCryptographicKeyService>();
+            services.AddTransient<CryptographicKeyService, TCryptographicKeyService>();
 
             return services;
         }
@@ -31,7 +31,7 @@ namespace OSK.Security.Cryptography
         {
             services.AddCryptography();
             services.TryAddTransient<AsymmetricKeyService<TKeyInformation>, TCryptographicKeyService>();
-            services.AddTransient<ICryptographicKeyService, TCryptographicKeyService>();
+            services.AddTransient<CryptographicKeyService, TCryptographicKeyService>();
 
             return services;
         }


### PR DESCRIPTION
Motivation
----
There is a limitation on the ICryptographicKeyServiceProvider that prevents getting a key service without knowing the typed key information. This makes the method unusable in some use cases.

Modifications
----
* Updated dependency injection extensions to include a generic typed DI descriptor
* Updated the ICryptographicKeyServiceProvider/CryptographicKeyServiceProvider to allow sending in generic key information
* Added UnitTests

Result
----
It is no longer required to know typed information to get a key service, as long as a key service has been registered on the DI that can handle the key information being requested

Fixes #11