### PR TITLE
Add better data signing handling (OSK-13)

### DIFF
--- a/src/OSK.Security.Cryptography.Abstractions/ClassicSigningAlgorithms.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ClassicSigningAlgorithms.cs
@@ -1,0 +1,41 @@
+﻿namespace OSK.Security.Cryptography.Abstractions
+{
+    public static class ClassicSigningAlgorithms
+    {
+        //
+        // Summary:
+        //     Gets a signing algorithm name that represents "MD5".
+        //
+        // Returns:
+        //     A signing algorithm name that represents "MD5".
+        public static CryptographicSigningAlgorithm MD5 { get; } = new CryptographicSigningAlgorithm("MD5");
+        //
+        // Summary:
+        //     Gets a signing algorithm name that represents "SHA1".
+        //
+        // Returns:
+        //     A signing algorithm name that represents "SHA1".
+        public static CryptographicSigningAlgorithm SHA1 { get; } = new CryptographicSigningAlgorithm("SHA1");
+        //
+        // Summary:
+        //     Gets a signing algorithm name that represents "SHA256".
+        //
+        // Returns:
+        //     A signing algorithm name that represents "SHA256".
+        public static CryptographicSigningAlgorithm SHA256 { get; } = new CryptographicSigningAlgorithm("SHA256");
+        //
+        // Summary:
+        //     Gets a signing algorithm name that represents "SHA384".
+        //
+        // Returns:
+        //     A signing algorithm name that represents "SHA384".
+        public static CryptographicSigningAlgorithm SHA384 { get; } = new CryptographicSigningAlgorithm("SHA384");
+        //
+        // Summary:
+        //     Gets a signing algorithm name that represents "SHA512".
+        //
+        // Returns:
+        //     A signing algorithm name that represents "SHA512".
+        public static CryptographicSigningAlgorithm SHA512 { get; } = new CryptographicSigningAlgorithm("SHA512");
+    }
+}

--- a/src/OSK.Security.Cryptography.Abstractions/CryptographicSigningAlgorithm.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/CryptographicSigningAlgorithm.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace OSK.Security.Cryptography.Abstractions
+{
+    public class CryptographicSigningAlgorithm
+    {
+        #region Variables
+
+        public string AlgorithmName { get; }
+
+        #endregion
+        
+        #region Constructors
+        
+        public CryptographicSigningAlgorithm(string algorithmName)
+        {
+            AlgorithmName = string.IsNullOrWhiteSpace(algorithmName)
+                ? throw new ArgumentNullException(nameof(algorithmName))
+                : algorithmName;
+        }
+        
+        #endregion
+    }
+}

--- a/src/OSK.Security.Cryptography.Abstractions/IAsymmetricKeyService.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/IAsymmetricKeyService.cs
@@ -1,5 +1,4 @@
-﻿using System.Security.Cryptography;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace OSK.Security.Cryptography.Abstractions
@@ -7,8 +6,8 @@ namespace OSK.Security.Cryptography.Abstractions
     public interface IAsymmetricKeyService<TKeyInformation> : ICryptographicKeyService<TKeyInformation>
         where TKeyInformation: IAsymmetricKeyInformation
     {
-        ValueTask<byte[]> SignAsync(byte[] data, HashAlgorithmName hashAlgorithmName, CancellationToken cancellationToken = default);
+        ValueTask<byte[]> SignAsync(byte[] data, CryptographicSigningAlgorithm signingAlgorithm, CancellationToken cancellationToken = default);
 
-        ValueTask<bool> ValidateSignatureAsync(byte[] data, byte[] signedData, HashAlgorithmName hashAlgorithmName, CancellationToken cancellationToken = default);
+        ValueTask<bool> ValidateSignatureAsync(byte[] data, byte[] signedData, CryptographicSigningAlgorithm signingAlgorithm, CancellationToken cancellationToken = default);
     }
 }

--- a/src/OSK.Security.Cryptography.UnitTests/Helpers/AsymmetricKeyTestService.cs
+++ b/src/OSK.Security.Cryptography.UnitTests/Helpers/AsymmetricKeyTestService.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Cryptography;
+﻿using OSK.Security.Cryptography.Abstractions;
 
 namespace OSK.Security.Cryptography.UnitTests.Helpers
 {
@@ -14,12 +14,12 @@ namespace OSK.Security.Cryptography.UnitTests.Helpers
             throw new NotImplementedException();
         }
 
-        public override ValueTask<byte[]> SignAsync(byte[] data, HashAlgorithmName hashAlgorithmName, CancellationToken cancellationToken = default)
+        public override ValueTask<byte[]> SignAsync(byte[] data, CryptographicSigningAlgorithm signingAlgorithm, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
 
-        public override ValueTask<bool> ValidateSignatureAsync(byte[] data, byte[] signedData, HashAlgorithmName hashAlgorithmName, CancellationToken cancellationToken = default)
+        public override ValueTask<bool> ValidateSignatureAsync(byte[] data, byte[] signedData, CryptographicSigningAlgorithm signingAlgorithm, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/src/OSK.Security.Cryptography/AsymmetricKeyService.cs
+++ b/src/OSK.Security.Cryptography/AsymmetricKeyService.cs
@@ -1,5 +1,7 @@
 ﻿using OSK.Security.Cryptography.Abstractions;
-using System.Security.Cryptography;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,10 +10,40 @@ namespace OSK.Security.Cryptography
     public abstract class AsymmetricKeyService<TKeyInformation> : CryptographicKeyService<TKeyInformation>, IAsymmetricKeyService<TKeyInformation>
         where TKeyInformation : class, IAsymmetricKeyInformation
     {
+        #region Variables
+
+        public virtual IEnumerable<CryptographicSigningAlgorithm> SupportedSigningAlgorithms { get; } = Enumerable.Empty<CryptographicSigningAlgorithm>();
+
+        #endregion
+
         #region IAsymmetricKey
 
-        public abstract ValueTask<byte[]> SignAsync(byte[] data, HashAlgorithmName hashAlgorithmName, CancellationToken cancellationToken = default);
-        public abstract ValueTask<bool> ValidateSignatureAsync(byte[] data, byte[] signedData, HashAlgorithmName hashAlgorithmName, CancellationToken cancellationToken = default);
+        public abstract ValueTask<byte[]> SignAsync(byte[] data, CryptographicSigningAlgorithm signingAlgorithm, CancellationToken cancellationToken = default);
+        public abstract ValueTask<bool> ValidateSignatureAsync(byte[] data, byte[] signedData, CryptographicSigningAlgorithm signingAlgorithm, CancellationToken cancellationToken = default);
+
+        #endregion
+
+        #region
+
+        protected void ValidateSigningAlgorithmSupport(CryptographicSigningAlgorithm signingAlgorithm)
+        {
+            if (signingAlgorithm == null)
+            {
+                throw new ArgumentNullException(nameof(signingAlgorithm));
+            }
+            // No specific signing algorithms set, so we'll let the consumer determine how to handle this
+            if (!SupportedSigningAlgorithms.Any())
+            {
+                return;
+            }
+
+            var supportedAlgorithm = SupportedSigningAlgorithms.FirstOrDefault(alg => alg.AlgorithmName.Equals(signingAlgorithm.AlgorithmName, StringComparison.OrdinalIgnoreCase));
+            if (supportedAlgorithm == null)
+            {
+                throw new ArgumentException($"The specified signing algorithm, {signingAlgorithm.AlgorithmName}, is not supported by key service of type {GetType().FullName}." +
+                    $" Please use any of the support algorithms: [{string.Join(", ", SupportedSigningAlgorithms.Select(a => a.AlgorithmName))}]");
+            }
+        }
 
         #endregion
     }


### PR DESCRIPTION
Motivation
----
The library is heavily integrated with HashAlgorithmNames for signing algorithms, but this does not work for some AsymmetricKeyService's that do not use a classic signing hash algorithm

Modifications
----
* [Breaking Change] - converted IAsymmetricKeyService to using new `CryptographicSigningAlgorithm` that can be extended by implementing Cryptography key service packages to special CryptographicSigningAlgorithms that they support

Result
----
There is a more flexible way to separate supported signing algorithms from a hardset list of hash algorithms

Fixes #13