### PR TITLE
Add better description and documentation handling (OSK-17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # OSK.Security.Cryptography
-Abstractions and base logic for handling a variety of cryptographic algorithms and keys in a flexible, easy way
+This library is meant to help with making cryptography more accessible, usable, and, hopefully, easier to use and extend. By utilizing a set of generic
+interfaces that defines common cryptographic security functions (encryption, decryption, signing, etc.), a user only needs to know the key information 
+they want to use (Aes, Rsa, etc.) and can rely on the internal mechanisms to provide the necessary cryptographic key services that will handle the
+security for the key. 
+
+# Abstractions
+The abstraction layer is meant to help provide a way to create different libraries that can handle and execute the core mechanisms for creating and handling
+key services integrated with the library. An implementation for the abstractions is provided for this process, which should hopefully fulfill most needs. 
+For any other libraries, `ICryptographicKeyServiceProvider` is meant to be the primary access point to the key services and should be implemented. Additionally,
+the `CryptographicKeyDescriptor` is meant to describe key services and should also be implemented. `ICryptographicKeyService` and `ICryptographicKeyInformation`
+implement the `IDisposable` interface and are meant to destroy any key and other sensitive data when destroyed. 
+
+# Usage: Adding Cryptographic Algorithm integrations
+Core to the internal logic is the `CryptographicKeyServiceProvider`, `CryptographicKeyService`, `SymmetricKeyService`, and `AsymmetricKeyService`
+objects. When implementing new algorithms and using the standard logic, one of these three key service types must be used since the base `CryptographicKeyService`
+exposes an internal method meant to help with initializing key information for a service. Additionally, the library utilizes dependency injection and it
+is expected that integrations will use this approach with the library and will call one of the dependency injection extension methods (see the ServiceCollectionExtensions at the root of the logic library)
+to add the necessary `CryptographicKeyDescriptor` used with the cryptographic key service provider. `ICryptographicKeyInformation` and `ICryptographicKeyService` should be considered sensitive and should be
+setup to destroy the sensitive cryptographic data when disposed. Only `IPublicKeyInformation` data should be considered safe for public exposure.
+
+Note: Individual implementations of the library can be standalone and may not require any of the above setup to be usable, however when being added to
+dependency injection flows with this library as an integration, it is expected that the above mentioned conventions are followed.
+
+# Usage: Consumers
+Consumers should inject the core logic using the `AddCryptography` extension to ensure the necessary services for operation are added to the dependency contianer.
+When wanting to utilize a cryptographic key service, users can call any of the methods on the `ICryptographicKeyServiceProvider` to get a key service that will handle encryption, 
+and other cryptographic functions. After using these functions, users should dispose of the key service and key information as soon as they are able for security risk management.
+Only the `IPublicKeyInformation` should be considered safe for public exposure. Users can then pick and choose the cryptographic services they need for their application by using 
+an implementation that follows the stated conventions in the above integration subheading and adding it to the dependency container.
+
+
+# Contributions and Issues
+Any and all contributions are appreciated! Please be sure to follow the branch naming convention `OSK-{issue number}-{deliminated}-{branch}-{name}` as current workflows rely on it for automatic issue closure.
+Please submit issues for discussion and tracking using the github issue tracker.

--- a/src/OSK.Security.Cryptography.Abstractions.UnitTests/OSK.Security.Cryptography.Abstractions.UnitTests.csproj
+++ b/src/OSK.Security.Cryptography.Abstractions.UnitTests/OSK.Security.Cryptography.Abstractions.UnitTests.csproj
@@ -6,10 +6,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/OSK.Security.Cryptography.Abstractions/ClassicSigningAlgorithms.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ClassicSigningAlgorithms.cs
@@ -1,5 +1,8 @@
 ﻿namespace OSK.Security.Cryptography.Abstractions
 {
+    /// <summary>
+    /// A set of classic signing algorithms for use with cryptographic signing functions.
+    /// </summary>
     public static class ClassicSigningAlgorithms
     {
         //

--- a/src/OSK.Security.Cryptography.Abstractions/CryptographicKeyAlgorithmType.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/CryptographicKeyAlgorithmType.cs
@@ -1,0 +1,21 @@
+﻿namespace OSK.Security.Cryptography.Abstractions
+{
+    /// <summary>
+    /// Represents the type of algorithm that a cryptographic key service utilizes 
+    /// </summary>
+    public enum CryptographicKeyAlgorithmType
+    {
+        /// <summary>
+        /// An algorithm that utilizes a single key to perform cryptography
+        /// </summary>
+        Symmetric,
+        /// <summary>
+        /// An algorithm that utilizes a private and public key pair to perform cryptography
+        /// </summary>
+        Asymmetric,
+        /// <summary>
+        /// The algorithm has an unspecified algorithm type. This could be for development/experimental purposes, or simply was not designated in the implementation.
+        /// </summary>
+        Unspecified
+    }
+}

--- a/src/OSK.Security.Cryptography.Abstractions/CryptographicKeyDescriptor.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/CryptographicKeyDescriptor.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace OSK.Security.Cryptography.Abstractions
+{
+    /// <summary>
+    /// Describes a cryptographic key implementation for the library
+    /// </summary>
+    public class CryptographicKeyDescriptor
+    {
+        /// <summary>
+        /// The name of the cryptographic algorithm, for display and/or debug purposes
+        /// </summary>
+        public string KeyAlgorithmName { get; set; }
+
+        public CryptographicKeyAlgorithmType KeyAlgorithmType { get; set; }
+
+        /// <summary>
+        /// The algorithm is currently in development and should not be considered a practical cryptographic implmentation for sensitive information
+        /// </summary>
+        public bool IsExperimental { get; set; }
+
+        /// <summary>
+        /// The type of key information this algorithm utilizes
+        /// </summary>
+        public Type KeyInformationType { get; set; }
+
+        /// <summary>
+        /// The type of key service that handles the designated key information
+        /// </summary>
+        public Type KeyServiceType { get; set; }
+    }
+}

--- a/src/OSK.Security.Cryptography.Abstractions/CryptographicSigningAlgorithm.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/CryptographicSigningAlgorithm.cs
@@ -3,6 +3,9 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace OSK.Security.Cryptography.Abstractions
 {
+    /// <summary>
+    /// A strongly typed way of describing signing algorithms. These can be unique per cryptographic algorithm.
+    /// </summary>
     public readonly struct CryptographicSigningAlgorithm : IEquatable<CryptographicSigningAlgorithm>
     {
         #region Variables

--- a/src/OSK.Security.Cryptography.Abstractions/IAsymmetricKeyInformation.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/IAsymmetricKeyInformation.cs
@@ -1,5 +1,11 @@
-﻿namespace OSK.Security.Cryptography.Abstractions
+﻿using OSK.Hexagonal.MetaData;
+
+namespace OSK.Security.Cryptography.Abstractions
 {
+    /// <summary>
+    /// A set of key information specific to asymmetric cryptographic algorithms
+    /// </summary>
+    [HexagonalPort(HexagonalPort.Secondary)]
     public interface IAsymmetricKeyInformation : ICryptographicKeyInformation
     {
     }

--- a/src/OSK.Security.Cryptography.Abstractions/IAsymmetricKeyService.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/IAsymmetricKeyService.cs
@@ -1,8 +1,10 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
+using OSK.Hexagonal.MetaData;
 
 namespace OSK.Security.Cryptography.Abstractions
 {
+    [HexagonalPort(HexagonalPort.Secondary)]
     public interface IAsymmetricKeyService<TKeyInformation> : ICryptographicKeyService<TKeyInformation>
         where TKeyInformation: IAsymmetricKeyInformation
     {

--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyInformation.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyInformation.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using OSK.Hexagonal.MetaData;
 
 namespace OSK.Security.Cryptography.Abstractions
 {
+    [HexagonalPort(HexagonalPort.Secondary)]
     public interface ICryptographicKeyInformation : IDisposable
     {
     }

--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyInformation`1.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyInformation`1.cs
@@ -1,8 +1,21 @@
-﻿namespace OSK.Security.Cryptography.Abstractions
+﻿using OSK.Hexagonal.MetaData;
+
+namespace OSK.Security.Cryptography.Abstractions
 {
+    /// <summary>
+    /// A set of key information that is used to initialize a key service. The data in this key is considered to a mix of sensitive and public key data 
+    /// and should not be shared. If key informations should be shared, please use <see cref="GetPublicKeyInformation"/>
+    /// </summary>
+    /// <typeparam name="TPublicKeyInformation">The type of public key information that is used to initialize the associated cryptographic key service</typeparam>
+    [HexagonalPort(HexagonalPort.Secondary)]
     public interface ICryptographicKeyInformation<TPublicKeyInformation>: ICryptographicKeyInformation
         where TPublicKeyInformation : IPublicKeyInformation
     {
+        /// <summary>
+        /// An accessor to getting publicly shareable key information for initializing cryptographic key algorithms
+        /// </summary>
+        /// <returns>Specific key information that is considered shareable to the public and will not risk revealing sensitive data encrypted by
+        /// the associated cryptographic key service</returns>
         public TPublicKeyInformation GetPublicKeyInformation();
     }
 }

--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService.cs
@@ -1,12 +1,26 @@
 ﻿using System.Threading.Tasks;
 using System.Threading;
+using OSK.Hexagonal.MetaData;
 
 namespace OSK.Security.Cryptography.Abstractions
 {
+    [HexagonalPort(HexagonalPort.Secondary)]
     public interface ICryptographicKeyService
     {
+        /// <summary>
+        /// Encrypts data using the cryptographic function internal algorithms
+        /// </summary>
+        /// <param name="data">The data to encrypt</param>
+        /// <param name="cancellationToken">A token to cancel the operation</param>
+        /// <returns>The encrypted data</returns>
         ValueTask<byte[]> EncryptAsync(byte[] data, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Decrypts data using the cryptographic function internal algorithms
+        /// </summary>
+        /// <param name="data">The encrypted data needing to be decrpyted</param>
+        /// <param name="cancellationToken">A token to cancel the operation</param>
+        /// <returns>The decrypted data</returns>
         ValueTask<byte[]> DecryptAsync(byte[] data, CancellationToken cancellationToken = default);
     }
 }

--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyServiceProvider.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyServiceProvider.cs
@@ -1,13 +1,36 @@
-﻿namespace OSK.Security.Cryptography.Abstractions
+﻿using OSK.Hexagonal.MetaData;
+
+namespace OSK.Security.Cryptography.Abstractions
 {
+    /// <summary>
+    /// The core accessor to the cryptographic key algorithms. The provider is meant to retrieve and initialize key information for any key service requested
+    /// </summary>
+    [HexagonalPort(HexagonalPort.Primary)]
     public interface ICryptographicKeyServiceProvider
     {
+        /// <summary>
+        /// Retrieves a symmetric key service that can handle the symmetric key information provided.
+        /// </summary>
+        /// <typeparam name="TKeyInformation"><see cref="ISymmetricKeyInformation"/></typeparam>
+        /// <param name="keyInformation">The symmetric that will be used to retrieve and initialize the symmetric key service</param>
+        /// <returns>The symmetric key service that can handle the key information passed.</returns>
         ISymmetricKeyService<TKeyInformation> GetSymmetricKeyService<TKeyInformation>(TKeyInformation keyInformation)
             where TKeyInformation : class, ISymmetricKeyInformation;
 
+        /// <summary>
+        /// Retrieves an asymmetric key service that can handle the asymmetric key information provided.
+        /// </summary>
+        /// <typeparam name="TKeyInformation"><see cref="IAsymmetricKeyInformation"/></typeparam>
+        /// <param name="keyInformation">The asymmetric that will be used to retrieve and initialize the asymmetric key service</param>
+        /// <returns>The asymmetric key service that can handle the key information passed.</returns>
         IAsymmetricKeyService<TKeyInformation> GetAsymmetricKeyService<TKeyInformation>(TKeyInformation keyInformation)
             where TKeyInformation : class, IAsymmetricKeyInformation;
 
+        /// <summary>
+        /// A generic accessor to a cryptographic key service, if a specific service type is not required for the consumer.
+        /// </summary>
+        /// <param name="keyInformation">Any <see cref="ICryptographicKeyInformation"/> that has been added to the dependency container to be used to retrieve and intiialize a key service that can handle the information.</param>
+        /// <returns>A cryptographic key service that can handle the key information passed.</returns>
         ICryptographicKeyService GetKeyService(ICryptographicKeyInformation keyInformation);
     }
 }

--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService`1.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService`1.cs
@@ -1,10 +1,15 @@
 ﻿using System;
+using OSK.Hexagonal.MetaData;
 
 namespace OSK.Security.Cryptography.Abstractions
 {
+    [HexagonalPort(HexagonalPort.Secondary)]
     public interface ICryptographicKeyService<TKeyInformation> : ICryptographicKeyService, IDisposable
         where TKeyInformation : ICryptographicKeyInformation
     {
+        /// <summary>
+        /// The key information to use with encryption or decryption. The data should be destroyed when the service is disposed.
+        /// </summary>
         TKeyInformation KeyInformation { get; }
     }
 }

--- a/src/OSK.Security.Cryptography.Abstractions/IPublicKeyInformation.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/IPublicKeyInformation.cs
@@ -1,5 +1,11 @@
-﻿namespace OSK.Security.Cryptography.Abstractions
+﻿using OSK.Hexagonal.MetaData;
+
+namespace OSK.Security.Cryptography.Abstractions
 {
+    /// <summary>
+    /// Represents key information that is meant to be public in order for cryptographic parameters to be shared.
+    /// </summary>
+    [HexagonalPort(HexagonalPort.Secondary)]
     public interface IPublicKeyInformation
     {
     }

--- a/src/OSK.Security.Cryptography.Abstractions/ISymmetricKeyInformation.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ISymmetricKeyInformation.cs
@@ -1,5 +1,8 @@
 ﻿namespace OSK.Security.Cryptography.Abstractions
 {
+    /// <summary>
+    /// A set of key information specific to symmetric cryptographic algorithms
+    /// </summary>
     public interface ISymmetricKeyInformation : ICryptographicKeyInformation
     {
     }

--- a/src/OSK.Security.Cryptography.Abstractions/ISymmetricKeyService.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ISymmetricKeyService.cs
@@ -1,5 +1,8 @@
-﻿namespace OSK.Security.Cryptography.Abstractions
+﻿using OSK.Hexagonal.MetaData;
+
+namespace OSK.Security.Cryptography.Abstractions
 {
+    [HexagonalPort(HexagonalPort.Secondary)]
     public interface ISymmetricKeyService<TKeyInformation> : ICryptographicKeyService<TKeyInformation>
         where TKeyInformation: ISymmetricKeyInformation
     {

--- a/src/OSK.Security.Cryptography.Abstractions/OSK.Security.Cryptography.Abstractions.csproj
+++ b/src/OSK.Security.Cryptography.Abstractions/OSK.Security.Cryptography.Abstractions.csproj
@@ -8,10 +8,21 @@
 		<PackageTags>OpenSourceKingdom, OpenSource, Abstraction, Cryptography, Security, Key, Encryption, Decryption, Signing, Verify</PackageTags>
 		<Authors>BlankDev117</Authors>
 		<Title>OSK.Security.Cryptography.Abstractions</Title>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>CS1591</NoWarn>
 	</PropertyGroup>
 
 	<PropertyGroup>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="OSK.Hexagonal.MetaData" Version="0.0.1" />
+	</ItemGroup>
 
 </Project>

--- a/src/OSK.Security.Cryptography.UnitTests/OSK.Security.Cryptography.UnitTests.csproj
+++ b/src/OSK.Security.Cryptography.UnitTests/OSK.Security.Cryptography.UnitTests.csproj
@@ -6,10 +6,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
-		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/OSK.Security.Cryptography/OSK.Security.Cryptography.csproj
+++ b/src/OSK.Security.Cryptography/OSK.Security.Cryptography.csproj
@@ -8,6 +8,9 @@
 		<PackageTags>OpenSourceKingdom, OpenSource, Cryptography, Security, Key, Encryption, Decryption, Signing, Verify</PackageTags>
 		<Authors>BlankDev117</Authors>
 		<Title>OSK.Security.Cryptography</Title>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<NoWarn>CS1591</NoWarn>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -15,7 +18,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+		<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OSK.Security.Cryptography/ServiceCollectionExtensions.cs
+++ b/src/OSK.Security.Cryptography/ServiceCollectionExtensions.cs
@@ -17,24 +17,53 @@ namespace OSK.Security.Cryptography
         public static IServiceCollection AddSymmetricKeyService<TCryptographicKeyService, TKeyInformation>(this IServiceCollection services)
             where TCryptographicKeyService : SymmetricKeyService<TKeyInformation>
             where TKeyInformation : class, ISymmetricKeyInformation
-        {
-            services.AddCryptography();
-            services.TryAddTransient<SymmetricKeyService<TKeyInformation>, TCryptographicKeyService>();
-            services.AddTransient<CryptographicKeyService, TCryptographicKeyService>();
+            => services.AddSymmetricKeyService <TCryptographicKeyService, TKeyInformation>(string.Empty);
 
-            return services;
+        public static IServiceCollection AddSymmetricKeyService<TCryptographicKeyService, TKeyInformation>(this IServiceCollection services,
+            string algorithmName, bool isExperimental = false)
+            where TCryptographicKeyService : SymmetricKeyService<TKeyInformation>
+            where TKeyInformation : class, ISymmetricKeyInformation
+        {
+            services.TryAddTransient<SymmetricKeyService<TKeyInformation>, TCryptographicKeyService>();
+            return services.AddCryptographicKeyDescriptor(new CryptographicKeyDescriptor()
+            {
+                KeyAlgorithmName = algorithmName,
+                KeyAlgorithmType = CryptographicKeyAlgorithmType.Symmetric,
+                IsExperimental = isExperimental,
+                KeyInformationType = typeof(TKeyInformation),
+                KeyServiceType = typeof(SymmetricKeyService<TKeyInformation>)
+            });
         }
 
         public static IServiceCollection AddAsymmetricKeyService<TCryptographicKeyService, TKeyInformation>(this IServiceCollection services)
             where TCryptographicKeyService : AsymmetricKeyService<TKeyInformation>
             where TKeyInformation : class, IAsymmetricKeyInformation
+            => services.AddAsymmetricKeyService<TCryptographicKeyService, TKeyInformation>(string.Empty);
+
+        public static IServiceCollection AddAsymmetricKeyService<TCryptographicKeyService, TKeyInformation>(this IServiceCollection services, 
+            string algorithmName, bool isExperimental = false)
+            where TCryptographicKeyService : AsymmetricKeyService<TKeyInformation>
+            where TKeyInformation : class, IAsymmetricKeyInformation
+        {
+            services.TryAddTransient<AsymmetricKeyService<TKeyInformation>, TCryptographicKeyService>();
+            return services.AddCryptographicKeyDescriptor(new CryptographicKeyDescriptor()
+            {
+                KeyAlgorithmName = algorithmName,
+                KeyAlgorithmType = CryptographicKeyAlgorithmType.Asymmetric,
+                IsExperimental = isExperimental,
+                KeyInformationType = typeof(TKeyInformation),
+                KeyServiceType = typeof(AsymmetricKeyService<TKeyInformation>)
+            });
+        }
+
+        public static IServiceCollection AddCryptographicKeyDescriptor(this IServiceCollection services, CryptographicKeyDescriptor keyDescriptor)
         {
             services.AddCryptography();
-            services.TryAddTransient<AsymmetricKeyService<TKeyInformation>, TCryptographicKeyService>();
-            services.AddTransient<CryptographicKeyService, TCryptographicKeyService>();
+            services.TryAddTransient(keyDescriptor.KeyServiceType);
+
+            services.AddSingleton(_ => keyDescriptor);
 
             return services;
         }
-
     }
 }

--- a/src/OSK.Security.Cryptography/SymmetricKeyService.cs
+++ b/src/OSK.Security.Cryptography/SymmetricKeyService.cs
@@ -2,6 +2,10 @@
 
 namespace OSK.Security.Cryptography
 {
+    /// <summary>
+    /// A key service that specifically uses <see cref="ISymmetricKeyInformation"/>.
+    /// </summary>
+    /// <typeparam name="TKeyInformation"><see cref="ISymmetricKeyInformation"/></typeparam>
     public abstract class SymmetricKeyService<TKeyInformation> : CryptographicKeyService<TKeyInformation>, ISymmetricKeyService<TKeyInformation>
         where TKeyInformation : class, ISymmetricKeyInformation
     {


### PR DESCRIPTION
Motivation
----
The current library doesn't have a decent README and the implementation doesn't provide a good way to see all currently added cryptographic key implementations to the dependency container

Modifications
----
* Updated documentation
* Added new CryptographicKeyDescriptor to help integrations describe an implementation via code
* Updated packages for security fixes

Result
----
library is better documented and has easier access to seeing integrations

Fixes #17