### PR TITLE
Update Hexagonal Metadata (OSK-19)

### DIFF
--- a/src/OSK.Security.Cryptography.Abstractions/IAsymmetricKeyInformation.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/IAsymmetricKeyInformation.cs
@@ -5,7 +5,7 @@ namespace OSK.Security.Cryptography.Abstractions
     /// <summary>
     /// A set of key information specific to asymmetric cryptographic algorithms
     /// </summary>
-    [HexagonalPort(HexagonalPort.Secondary)]
+    [HexagonalIntegration(HexagonalIntegrationType.IntegrationRequired)]
     public interface IAsymmetricKeyInformation : ICryptographicKeyInformation
     {
     }

--- a/src/OSK.Security.Cryptography.Abstractions/IAsymmetricKeyService.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/IAsymmetricKeyService.cs
@@ -4,7 +4,7 @@ using OSK.Hexagonal.MetaData;
 
 namespace OSK.Security.Cryptography.Abstractions
 {
-    [HexagonalPort(HexagonalPort.Secondary)]
+    [HexagonalIntegration(HexagonalIntegrationType.IntegrationRequired)]
     public interface IAsymmetricKeyService<TKeyInformation> : ICryptographicKeyService<TKeyInformation>
         where TKeyInformation: IAsymmetricKeyInformation
     {

--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyInformation.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyInformation.cs
@@ -3,7 +3,7 @@ using OSK.Hexagonal.MetaData;
 
 namespace OSK.Security.Cryptography.Abstractions
 {
-    [HexagonalPort(HexagonalPort.Secondary)]
+    [HexagonalIntegration(HexagonalIntegrationType.IntegrationRequired)]
     public interface ICryptographicKeyInformation : IDisposable
     {
     }

--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyInformation`1.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyInformation`1.cs
@@ -7,7 +7,7 @@ namespace OSK.Security.Cryptography.Abstractions
     /// and should not be shared. If key informations should be shared, please use <see cref="GetPublicKeyInformation"/>
     /// </summary>
     /// <typeparam name="TPublicKeyInformation">The type of public key information that is used to initialize the associated cryptographic key service</typeparam>
-    [HexagonalPort(HexagonalPort.Secondary)]
+    [HexagonalIntegration(HexagonalIntegrationType.IntegrationRequired)]
     public interface ICryptographicKeyInformation<TPublicKeyInformation>: ICryptographicKeyInformation
         where TPublicKeyInformation : IPublicKeyInformation
     {

--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService.cs
@@ -4,7 +4,7 @@ using OSK.Hexagonal.MetaData;
 
 namespace OSK.Security.Cryptography.Abstractions
 {
-    [HexagonalPort(HexagonalPort.Secondary)]
+    [HexagonalIntegration(HexagonalIntegrationType.IntegrationRequired)]
     public interface ICryptographicKeyService
     {
         /// <summary>

--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyServiceProvider.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyServiceProvider.cs
@@ -5,7 +5,7 @@ namespace OSK.Security.Cryptography.Abstractions
     /// <summary>
     /// The core accessor to the cryptographic key algorithms. The provider is meant to retrieve and initialize key information for any key service requested
     /// </summary>
-    [HexagonalPort(HexagonalPort.Primary)]
+    [HexagonalIntegration(HexagonalIntegrationType.LibraryProvided, HexagonalIntegrationType.ConsumerPointOfEntry)]
     public interface ICryptographicKeyServiceProvider
     {
         /// <summary>

--- a/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService`1.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ICryptographicKeyService`1.cs
@@ -3,7 +3,7 @@ using OSK.Hexagonal.MetaData;
 
 namespace OSK.Security.Cryptography.Abstractions
 {
-    [HexagonalPort(HexagonalPort.Secondary)]
+    [HexagonalIntegration(HexagonalIntegrationType.IntegrationRequired)]
     public interface ICryptographicKeyService<TKeyInformation> : ICryptographicKeyService, IDisposable
         where TKeyInformation : ICryptographicKeyInformation
     {

--- a/src/OSK.Security.Cryptography.Abstractions/IPublicKeyInformation.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/IPublicKeyInformation.cs
@@ -5,7 +5,7 @@ namespace OSK.Security.Cryptography.Abstractions
     /// <summary>
     /// Represents key information that is meant to be public in order for cryptographic parameters to be shared.
     /// </summary>
-    [HexagonalPort(HexagonalPort.Secondary)]
+    [HexagonalIntegration(HexagonalIntegrationType.IntegrationRequired)]
     public interface IPublicKeyInformation
     {
     }

--- a/src/OSK.Security.Cryptography.Abstractions/ISymmetricKeyInformation.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ISymmetricKeyInformation.cs
@@ -1,8 +1,11 @@
-﻿namespace OSK.Security.Cryptography.Abstractions
+﻿using OSK.Hexagonal.MetaData;
+
+namespace OSK.Security.Cryptography.Abstractions
 {
     /// <summary>
     /// A set of key information specific to symmetric cryptographic algorithms
     /// </summary>
+    [HexagonalIntegration(HexagonalIntegrationType.IntegrationRequired)]
     public interface ISymmetricKeyInformation : ICryptographicKeyInformation
     {
     }

--- a/src/OSK.Security.Cryptography.Abstractions/ISymmetricKeyService.cs
+++ b/src/OSK.Security.Cryptography.Abstractions/ISymmetricKeyService.cs
@@ -2,7 +2,7 @@
 
 namespace OSK.Security.Cryptography.Abstractions
 {
-    [HexagonalPort(HexagonalPort.Secondary)]
+    [HexagonalIntegration(HexagonalIntegrationType.IntegrationRequired)]
     public interface ISymmetricKeyService<TKeyInformation> : ICryptographicKeyService<TKeyInformation>
         where TKeyInformation: ISymmetricKeyInformation
     {

--- a/src/OSK.Security.Cryptography.Abstractions/OSK.Security.Cryptography.Abstractions.csproj
+++ b/src/OSK.Security.Cryptography.Abstractions/OSK.Security.Cryptography.Abstractions.csproj
@@ -22,7 +22,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="OSK.Hexagonal.MetaData" Version="0.0.1" />
+	  <PackageReference Include="OSK.Hexagonal.MetaData" Version="0.1.1" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Motivation
----
current metadata package is out of date

Modifications
----
* Updated to latest convetions for meta data on ports

Result
----
Better port documentation

Fixes #19